### PR TITLE
Add script to submit certificates to a CT server

### DIFF
--- a/submit/submit.go
+++ b/submit/submit.go
@@ -2,18 +2,53 @@ package main
 
 import (
 	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"fmt"
+	"io/ioutil"
 	"log"
+	"math/big"
 	"net/http"
 
 	"flag"
 
-	"github.com/cloudflare/cfssl/certdb/dbconf"
-	"github.com/cloudflare/cfssl/certdb/sql"
+	"github.com/cloudflare/cfssl/helpers"
+	ct "github.com/google/certificate-transparency/go"
 	logclient "github.com/google/certificate-transparency/go/client"
 	"github.com/google/certificate-transparency/go/jsonclient"
 
 	_ "github.com/mattn/go-sqlite3"
 )
+
+func makeCertificate(root *x509.Certificate, rootKey crypto.Signer) ([]byte, error) {
+	serialNumberRange := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNumber, err := rand.Int(rand.Reader, serialNumberRange)
+	if err != nil {
+		return nil, err
+	}
+
+	template := x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			Organization: []string{"Cornell CS 5152"},
+		},
+		AuthorityKeyId: []byte{42, 42, 42, 42},
+	}
+	// // Generate a CA certificate
+	// issuerTemplate := x509.Certificate{
+	// 	SerialNumber: issuerSerial,
+	// 	Subject: pkix.Name{
+	// 		Organization: []string{"Cornell CS 5152"},
+	// 	},
+	// 	AuthorityKeyId: []byte{42, 42, 42, 42},
+	// 	KeyUsage:       x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+	// 	IsCA:           true,
+	// 	BasicConstraintsValid: true,
+	// }
+	return x509.CreateCertificate(rand.Reader, &template, root, rootKey.Public(), rootKey)
+}
 
 func main() {
 	var host string
@@ -28,29 +63,80 @@ func main() {
 	ctx := context.Background()
 
 	log.Print("Creating client...")
-	logclient, err := logclient.New("localhost:6962", client, options)
+	logclient, err := logclient.New("http://localhost:6962", client, options)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	log.Print("Opening db...")
-	db, err := dbconf.DBFromConfig(dbConfig)
+	// Get the accepted roots
+	roots, err := logclient.GetAcceptedRoots(ctx)
 	if err != nil {
-		log.Print(dbConfig)
-		log.Fatal("Could not load certdb: ", err, dbConfig)
+		log.Fatal(err)
 	}
+	if roots == nil {
+		log.Fatal("No accepted roots?")
+	}
+	fmt.Println(roots)
 
-	log.Print("Creating certdb...")
-	dbAccessor := sql.NewAccessor(db)
+	// certdata, err := ioutil.ReadFile("/home/lidavidm/Code/gohome/src/github.com/google/trillian/testdata/int-ca.cert")
+	// if err != nil {
+	// 	log.Fatal(err)
+	// }
+	// certchain := testonly.CertsFromPEM(certdata)
+	// sct, err := logclient.AddChain(ctx, certchain)
+	// if err != nil {
+	// 	log.Fatal(err)
+	// }
+	// log.Println(sct)
 
-	log.Print("Getting certificates...")
-	certs, err := dbAccessor.GetUnexpiredCertificates()
+	rootData, err := ioutil.ReadFile("fake-ca.cert")
+	if err != nil {
+		log.Fatal(err)
+	}
+	root, err := helpers.ParseCertificatePEM(rootData)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	for _ = range certs {
-		log.Print("Submitting a cert...")
-		logclient.AddChain(ctx, nil)
+	rootKeyData, err := ioutil.ReadFile("fake-ca.privkey.pem")
+	if err != nil {
+		log.Fatal(err)
 	}
+	rootKey, err := helpers.ParsePrivateKeyPEMWithPassword(rootKeyData, []byte("gently"))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	cert, err := makeCertificate(root, rootKey)
+	if err != nil {
+		log.Fatal(err)
+	}
+	sct, err := logclient.AddChain(ctx, []ct.ASN1Cert{{Data: cert}})
+	log.Println(sct)
+
+	// _, err = logclient.AddChain(ctx, []ct.ASN1Cert{{Data: root.Raw}})
+	// if err != nil {
+	// 	log.Fatal(err)
+	// }
+
+	// log.Print("Opening db...")
+	// db, err := dbconf.DBFromConfig(dbConfig)
+	// if err != nil {
+	// 	log.Print(dbConfig)
+	// 	log.Fatal("Could not load certdb: ", err, dbConfig)
+	// }
+
+	// log.Print("Creating certdb...")
+	// dbAccessor := sql.NewAccessor(db)
+
+	// log.Print("Getting certificates...")
+	// certs, err := dbAccessor.GetUnexpiredCertificates()
+	// if err != nil {
+	// 	log.Fatal(err)
+	// }
+
+	// for _ = range certs {
+	// 	log.Print("Submitting a cert...")
+	// 	logclient.AddChain(ctx, nil)
+	// }
 }

--- a/submit/submit.go
+++ b/submit/submit.go
@@ -30,7 +30,7 @@ func main() {
 	ctx := context.Background()
 
 	log.Print("Creating client...")
-	logclient, err := logclient.New("http://localhost:6962", client, options)
+	logclient, err := logclient.New(host, client, options)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/submit/submit.go
+++ b/submit/submit.go
@@ -2,18 +2,13 @@ package main
 
 import (
 	"context"
-	"crypto"
-	"crypto/rand"
-	"crypto/x509"
-	"crypto/x509/pkix"
-	"fmt"
-	"io/ioutil"
 	"log"
-	"math/big"
 	"net/http"
 
 	"flag"
 
+	"github.com/cloudflare/cfssl/certdb/dbconf"
+	"github.com/cloudflare/cfssl/certdb/sql"
 	"github.com/cloudflare/cfssl/helpers"
 	ct "github.com/google/certificate-transparency/go"
 	logclient "github.com/google/certificate-transparency/go/client"
@@ -21,34 +16,6 @@ import (
 
 	_ "github.com/mattn/go-sqlite3"
 )
-
-func makeCertificate(root *x509.Certificate, rootKey crypto.Signer) ([]byte, error) {
-	serialNumberRange := new(big.Int).Lsh(big.NewInt(1), 128)
-	serialNumber, err := rand.Int(rand.Reader, serialNumberRange)
-	if err != nil {
-		return nil, err
-	}
-
-	template := x509.Certificate{
-		SerialNumber: serialNumber,
-		Subject: pkix.Name{
-			Organization: []string{"Cornell CS 5152"},
-		},
-		AuthorityKeyId: []byte{42, 42, 42, 42},
-	}
-	// // Generate a CA certificate
-	// issuerTemplate := x509.Certificate{
-	// 	SerialNumber: issuerSerial,
-	// 	Subject: pkix.Name{
-	// 		Organization: []string{"Cornell CS 5152"},
-	// 	},
-	// 	AuthorityKeyId: []byte{42, 42, 42, 42},
-	// 	KeyUsage:       x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
-	// 	IsCA:           true,
-	// 	BasicConstraintsValid: true,
-	// }
-	return x509.CreateCertificate(rand.Reader, &template, root, rootKey.Public(), rootKey)
-}
 
 func main() {
 	var host string
@@ -68,75 +35,36 @@ func main() {
 		log.Fatal(err)
 	}
 
-	// Get the accepted roots
-	roots, err := logclient.GetAcceptedRoots(ctx)
+	log.Print("Opening db...")
+	db, err := dbconf.DBFromConfig(dbConfig)
 	if err != nil {
-		log.Fatal(err)
+		log.Print(dbConfig)
+		log.Fatal("Could not load certdb: ", err, dbConfig)
 	}
-	if roots == nil {
-		log.Fatal("No accepted roots?")
-	}
-	fmt.Println(roots)
 
-	// certdata, err := ioutil.ReadFile("/home/lidavidm/Code/gohome/src/github.com/google/trillian/testdata/int-ca.cert")
-	// if err != nil {
-	// 	log.Fatal(err)
-	// }
-	// certchain := testonly.CertsFromPEM(certdata)
-	// sct, err := logclient.AddChain(ctx, certchain)
-	// if err != nil {
-	// 	log.Fatal(err)
-	// }
-	// log.Println(sct)
+	log.Print("Creating certdb...")
+	dbAccessor := sql.NewAccessor(db)
 
-	rootData, err := ioutil.ReadFile("fake-ca.cert")
-	if err != nil {
-		log.Fatal(err)
-	}
-	root, err := helpers.ParseCertificatePEM(rootData)
+	log.Print("Getting certificates...")
+	certs, err := dbAccessor.GetUnexpiredCertificates()
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	rootKeyData, err := ioutil.ReadFile("fake-ca.privkey.pem")
-	if err != nil {
-		log.Fatal(err)
+	for _, cr := range certs {
+		log.Print("Submitting a cert...")
+		var chain []ct.ASN1Cert
+
+		certs, err := helpers.ParseCertificatesPEM([]byte(cr.PEM))
+		if err != nil {
+			log.Fatal("Could not parse PEM", err)
+			continue
+		}
+
+		for _, cert := range certs {
+			chain = append(chain, ct.ASN1Cert{Data: cert.Raw})
+		}
+
+		logclient.AddChain(ctx, chain)
 	}
-	rootKey, err := helpers.ParsePrivateKeyPEMWithPassword(rootKeyData, []byte("gently"))
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	cert, err := makeCertificate(root, rootKey)
-	if err != nil {
-		log.Fatal(err)
-	}
-	sct, err := logclient.AddChain(ctx, []ct.ASN1Cert{{Data: cert}})
-	log.Println(sct)
-
-	// _, err = logclient.AddChain(ctx, []ct.ASN1Cert{{Data: root.Raw}})
-	// if err != nil {
-	// 	log.Fatal(err)
-	// }
-
-	// log.Print("Opening db...")
-	// db, err := dbconf.DBFromConfig(dbConfig)
-	// if err != nil {
-	// 	log.Print(dbConfig)
-	// 	log.Fatal("Could not load certdb: ", err, dbConfig)
-	// }
-
-	// log.Print("Creating certdb...")
-	// dbAccessor := sql.NewAccessor(db)
-
-	// log.Print("Getting certificates...")
-	// certs, err := dbAccessor.GetUnexpiredCertificates()
-	// if err != nil {
-	// 	log.Fatal(err)
-	// }
-
-	// for _ = range certs {
-	// 	log.Print("Submitting a cert...")
-	// 	logclient.AddChain(ctx, nil)
-	// }
 }

--- a/submit/submit.go
+++ b/submit/submit.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"context"
+	"log"
+	"net/http"
+
+	"flag"
+
+	"github.com/cloudflare/cfssl/certdb/dbconf"
+	"github.com/cloudflare/cfssl/certdb/sql"
+	logclient "github.com/google/certificate-transparency/go/client"
+	"github.com/google/certificate-transparency/go/jsonclient"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+func main() {
+	var host string
+	var dbConfig string
+	flag.StringVar(&host, "host", "localhost:6962", "The URL to the CT server.")
+	flag.StringVar(&dbConfig, "dbConfig", "", "The certdb config path.")
+
+	flag.Parse()
+
+	client := http.DefaultClient
+	options := jsonclient.Options{}
+	ctx := context.Background()
+
+	log.Print("Creating client...")
+	logclient, err := logclient.New("localhost:6962", client, options)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	log.Print("Opening db...")
+	db, err := dbconf.DBFromConfig(dbConfig)
+	if err != nil {
+		log.Print(dbConfig)
+		log.Fatal("Could not load certdb: ", err, dbConfig)
+	}
+
+	log.Print("Creating certdb...")
+	dbAccessor := sql.NewAccessor(db)
+
+	log.Print("Getting certificates...")
+	certs, err := dbAccessor.GetUnexpiredCertificates()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for _ = range certs {
+		log.Print("Submitting a cert...")
+		logclient.AddChain(ctx, nil)
+	}
+}


### PR DESCRIPTION
This script loads all the unexpired certificates in a certdb and uses the Go client code to submit them to a CT server, one by one.

If the CT server is using the `fake-ca.cert` trusted root (provided as part of Trillian), then this following script, given an existing certdb, will load it and populate it with fake certificates to test with. It needs both `fake-ca.cert` and `fake-ca.privkey.pem` in the current directory (both of which are in the `testdata/` directory of Trillian).

```
package main

import (
	"crypto"
	"crypto/rand"
	"crypto/x509"
	"crypto/x509/pkix"
	"encoding/hex"
	"io/ioutil"
	"log"
	"math/big"

	"flag"

	"github.com/cloudflare/cfssl/certdb"
	"github.com/cloudflare/cfssl/certdb/dbconf"
	"github.com/cloudflare/cfssl/certdb/sql"
	"github.com/cloudflare/cfssl/helpers"

	"time"

	"encoding/pem"

	_ "github.com/mattn/go-sqlite3"
)

func makeCertificate(root *x509.Certificate, rootKey crypto.Signer) (*big.Int, []byte, []byte, error) {
	serialNumberRange := new(big.Int).Lsh(big.NewInt(1), 128)
	serialNumber, err := rand.Int(rand.Reader, serialNumberRange)
	if err != nil {
		return nil, nil, nil, err
	}

	template := x509.Certificate{
		SerialNumber: serialNumber,
		Subject: pkix.Name{
			Organization: []string{"Cornell CS 5152"},
		},
		AuthorityKeyId: []byte{42, 42, 42, 42},
	}
	cert, err := x509.CreateCertificate(rand.Reader, &template, root, rootKey.Public(), rootKey)
	return serialNumber, []byte{42, 42, 42, 42}, cert, err
}

func main() {
	var dbConfig string
	flag.StringVar(&dbConfig, "dbConfig", "", "The certdb config path.")

	flag.Parse()

	db, err := dbconf.DBFromConfig(dbConfig)
	if err != nil {
		log.Print(dbConfig)
		log.Fatal("Could not load certdb: ", err, dbConfig)
	}

	dbAccessor := sql.NewAccessor(db)

	rootData, err := ioutil.ReadFile("fake-ca.cert")
	if err != nil {
		log.Fatal(err)
	}
	root, err := helpers.ParseCertificatePEM(rootData)
	if err != nil {
		log.Fatal(err)
	}

	rootKeyData, err := ioutil.ReadFile("fake-ca.privkey.pem")
	if err != nil {
		log.Fatal(err)
	}
	rootKey, err := helpers.ParsePrivateKeyPEMWithPassword(rootKeyData, []byte("gently"))
	if err != nil {
		log.Fatal(err)
	}

	for i := 0; i < 20; i++ {
		serial, aki, cert, err := makeCertificate(root, rootKey)

		if err != nil {
			log.Fatal(err)
		}

		if err := dbAccessor.InsertCertificate(certdb.CertificateRecord{
			Serial: serial.Text(16),
			AKI:    hex.EncodeToString(aki),
			PEM: string(pem.EncodeToMemory(&pem.Block{
				Type:  "CERTIFICATE",
				Bytes: cert,
			})),
			Expiry: time.Now().Add(365 * 24 * time.Hour),
		}); err != nil {
			log.Println(err)
			continue
		}
	}
}
```